### PR TITLE
Remove Notes from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,3 @@ Rotation of meeting leaders: [@edolstra](https://github.com/edolstra), [@Mic92](
 
 ## After meeting
 - Meeting leader puts agenda/notes in a [new issue](https://github.com/NixOS/rfc-steering-committee/issues/new)
-
-# Notes
-
-## RFC Leaders
-
-- responsible for advertizing and pushing RFC forward


### PR DESCRIPTION
It is not entirely clear what that section is supposed to mean in this repo. The terminology `RFC leaders` isn't used elsewhere and it is a bit confusing while trying to understand the RFC process.