### PR TITLE
scripts: add rotation info as markdown comment

### DIFF
--- a/rfc-report.sh
+++ b/rfc-report.sh
@@ -18,7 +18,7 @@ cat <<EOF
 ## Discussion points
 
 ## Leader of next meeting
-
+<!-- rotation: @edolstra, @Mic92, @spacekookie, @lheckemann, @kloenk -->
 REPLACE will lead the next meeting on YYYY-MM-DD
 
 pad.mayflower.de/nixos-rfc-steering-committee


### PR DESCRIPTION
This adds the rotation info comment into the generated markdown