### PR TITLE
rfc-report: add section for "revived" RFCs

### DIFF
--- a/rfc-report.jq
+++ b/rfc-report.jq
@@ -7,14 +7,14 @@ def has_label(l): .labels | any(.name == l);
   | length as $length
   | sort_by(.number)
   | [
-    { title: "Draft RFCs", items: map(select(has_label("status: draft") and .draft)) },
-    { title: "Revived RFCs", items: map(select(has_label("status: draft") and (.draft | not))) },
-    { title: "Unlabelled and New RFCs", items: map(select(isempty(.labels | .[]) or has_label("status: new"))) },
-    { title: "RFCs Open for Nominations", items: map(select(has_label("status: open for nominations"))) },
-    { title: "RFCs in Discussion", items: map(select(has_label("status: in discussion"))) },
-    { title: "RFCs in FCP", items: map(select(has_label("status: FCP"))) },
-    { title: "Accepted/Rejected/Closed", items: map(select(.closed_at > $closed_since)) }
-  ]
+    { title: "Draft RFCs", items: map(select(.draft)) }
+  ] + (map(select(.draft | not)) | [
+      { title: "Unlabelled and New RFCs", items: map(select(isempty(.labels | .[]) or has_label("status: new"))) },
+      { title: "RFCs Open for Nominations", items: map(select(has_label("status: open for nominations"))) },
+      { title: "RFCs in Discussion", items: map(select(has_label("status: in discussion"))) },
+      { title: "RFCs in FCP", items: map(select(has_label("status: FCP"))) },
+      { title: "Accepted/Rejected/Closed", items: map(select(.closed_at > $closed_since)) }
+  ])
   | map("## " + .title + "\n\n" + (.items | issue_items))
   | join("\n")
   | "<!-- " + ($length | tostring) + " PRs processed -->\n\n" + .

--- a/rfc-report.jq
+++ b/rfc-report.jq
@@ -1,4 +1,4 @@
-def issue_item(last_meeting): "* [ ] [RFC " + (.number | tostring) + ": " + (.title | sub("\\[(RFC)? ?[0-9]+\\]?:? *"; "")) + "](" + .html_url + ")" + if .updated_at > last_meeting then " <!-- updated since last meeting -->" else "" end;
+def issue_item(last_meeting): "* [ ] [RFC \(.number | tostring): \(.title | sub("\\[(RFC)? ?[0-9]+\\]?:? *"; ""))](\(.html_url))" + (if (.updated_at > last_meeting) then " <!-- updated since last meeting -->" else "" end);
 def issue_items(last_meeting): if isempty(.[]) then "None" else map(issue_item(last_meeting)) | join("\n") end + "\n\n";
 def has_label(l): .labels | any(.name == l);
 

--- a/rfc-report.jq
+++ b/rfc-report.jq
@@ -1,9 +1,9 @@
-def issue_item: "* [ ] [RFC " + (.number | tostring) + ": " + (.title | sub("\\[(RFC)? ?[0-9]+\\]?:? *"; "")) + "](" + .html_url + ")";
-def issue_items: if isempty(.[]) then "None" else map(issue_item) | join("\n") end + "\n\n";
+def issue_item(last_meeting): "* [ ] [RFC " + (.number | tostring) + ": " + (.title | sub("\\[(RFC)? ?[0-9]+\\]?:? *"; "")) + "](" + .html_url + ")" + if .updated_at > last_meeting then " <!-- updated since last meeting -->" else "" end;
+def issue_items(last_meeting): if isempty(.[]) then "None" else map(issue_item(last_meeting)) | join("\n") end + "\n\n";
 def has_label(l): .labels | any(.name == l);
 
 .
-  | ($ENV.CLOSED_SINCE // error("Define env var CLOSED_SINCE as the date to compare to")) as $closed_since
+  | ($ENV.LAST_MEETING // error("Define env var LAST_MEETING as the timestamp to compare to")) as $last_meeting
   | length as $length
   | sort_by(.number)
   | [
@@ -13,8 +13,8 @@ def has_label(l): .labels | any(.name == l);
       { title: "RFCs Open for Nominations", items: map(select(has_label("status: open for nominations"))) },
       { title: "RFCs in Discussion", items: map(select(has_label("status: in discussion"))) },
       { title: "RFCs in FCP", items: map(select(has_label("status: FCP"))) },
-      { title: "Accepted/Rejected/Closed", items: map(select(.closed_at > $closed_since)) }
+      { title: "Accepted/Rejected/Closed", items: map(select(.closed_at > $last_meeting)) }
   ])
-  | map("## " + .title + "\n\n" + (.items | issue_items))
+  | map("## " + .title + "\n\n" + (.items | issue_items($last_meeting)))
   | join("\n")
   | "<!-- " + ($length | tostring) + " PRs processed -->\n\n" + .

--- a/rfc-report.jq
+++ b/rfc-report.jq
@@ -7,7 +7,8 @@ def has_label(l): .labels | any(.name == l);
   | length as $length
   | sort_by(.number)
   | [
-    { title: "Draft RFCs", items: map(select(has_label("status: draft"))) },
+    { title: "Draft RFCs", items: map(select(has_label("status: draft") and .draft)) },
+    { title: "Revived RFCs", items: map(select(has_label("status: draft") and (.draft | not))) },
     { title: "Unlabelled and New RFCs", items: map(select(isempty(.labels | .[]) or has_label("status: new"))) },
     { title: "RFCs Open for Nominations", items: map(select(has_label("status: open for nominations"))) },
     { title: "RFCs in Discussion", items: map(select(has_label("status: in discussion"))) },

--- a/rfc-report.sh
+++ b/rfc-report.sh
@@ -18,7 +18,7 @@ cat <<EOF
 ## Discussion points
 
 ## Leader of next meeting
-<!-- rotation: @edolstra, @spacekookie, @lheckemann, @kevincox, @tomberek -->
+<!-- rotation: @edolstra, @lheckemann, @kevincox, @spacekookie, @tomberek -->
 REPLACE will lead the next meeting on YYYY-MM-DD
 
 pad.mayflower.de/nixos-rfc-steering-committee

--- a/rfc-report.sh
+++ b/rfc-report.sh
@@ -2,7 +2,8 @@
 #!nix-shell -i bash -p jq hub
 
 set -euo pipefail
-export CLOSED_SINCE=$(date -I -d "2 weeks ago")
+IFS= read -rp "Last meeting was (default '2 weeks ago', example '2022-12-14')? " last_meeting >&2
+export LAST_MEETING=$(date -I -d "${last_meeting:-2 weeks ago}")
 
 cat <<EOF
 ## General business


### PR DESCRIPTION
These are RFCs which are still labelled as drafts by the steering
committee but have been marked as ready for review by the
authors. This indicates that they should go back on our radar.