### PR TITLE
rfc-report: Use the official GitHub CLI

### DIFF
--- a/rfc-report.py
+++ b/rfc-report.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p hub python3
+#!nix-shell -i python3 -p github-cli python3
 
 import datetime
 import json
 import os
 import re
 import subprocess
-
-if "GITHUB_TOKEN" not in os.environ:
-	print("WARNING: GITHUB_TOKEN is not set, this script will be very slow")
 
 LABEL_IN_FCP = "status: FCP"
 LABEL_IN_DISCUSSION = "status: in discussion"
@@ -27,7 +24,7 @@ print()
 
 def github_api(url):
 	p = subprocess.run([
-		"hub",
+		"gh",
 		"api",
 		"--paginate",
 		url


### PR DESCRIPTION
The official GitHub CLI has pretty much the same interface, however it requires authentication. This is nice because `hub` is way too slow without that anyways.

If you aren't authenticated, it prints this:

```
To get started with GitHub CLI, please run:  gh auth login
Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
```

`GITHUB_TOKEN` also works however.

Meanwhile `gh auth login` takes you through a fairly easy browser-based authentication.